### PR TITLE
Correct Tado interface name

### DIFF
--- a/tado_aa.py
+++ b/tado_aa.py
@@ -11,7 +11,7 @@ import time
 import inspect
 
 from datetime import datetime
-from PyTado.interface.interface import Tado
+from PyTado.interface import Tado
 
 def main():
 


### PR DESCRIPTION
Since the changes to enable OAuth3, the interface namespace was incorrectly duplicated.

```
Traceback (most recent call last):
  File "/home/tado/tado_aa/tado_aa.py", line 14, in <module>
    from PyTado.interface.interface import Tado
ModuleNotFoundError: No module named 'PyTado.interface.interface'; 'PyTado.interface' is not a package

```
This PR fixes that, and `tado_aa.py` will run again